### PR TITLE
[#7] Do not display security credentials

### DIFF
--- a/generic-jms-ra-jar/src/main/java/org/jboss/resource/adapter/jms/inflow/JmsActivation.java
+++ b/generic-jms-ra-jar/src/main/java/org/jboss/resource/adapter/jms/inflow/JmsActivation.java
@@ -309,12 +309,17 @@ public class JmsActivation implements ExceptionListener {
     }
 
     public static Context convertStringToContext(String jndiParameters) throws NamingException {
-        InitialContext result = null;
-
-        if (jndiParameters == null) {
-            result = new InitialContext();
+        Properties properties = convertStringToProperties(jndiParameters);
+        if (properties.isEmpty()) {
+            return new InitialContext();
         } else {
-            Properties properties = new Properties();
+            return new InitialContext(properties);
+        }
+    }
+
+    static Properties convertStringToProperties(String jndiParameters) {
+        Properties properties = new Properties();
+        if (jndiParameters != null) {
             String[] elements = jndiParameters.split(";");
             for (String element : elements) {
                 String[] nameValue = element.split("=");
@@ -322,11 +327,8 @@ public class JmsActivation implements ExceptionListener {
                     properties.setProperty(nameValue[0], nameValue[1]);
                 }
             }
-
-            result = new InitialContext(properties);
         }
-
-        return result;
+        return properties;
     }
 
     /**

--- a/generic-jms-ra-jar/src/main/java/org/jboss/resource/adapter/jms/inflow/JmsActivationSpec.java
+++ b/generic-jms-ra-jar/src/main/java/org/jboss/resource/adapter/jms/inflow/JmsActivationSpec.java
@@ -21,10 +21,13 @@
  */
 package org.jboss.resource.adapter.jms.inflow;
 
+import java.util.Properties;
+
 import javax.jms.Destination;
 import javax.jms.Queue;
 import javax.jms.Session;
 import javax.jms.Topic;
+import javax.naming.Context;
 import javax.resource.ResourceException;
 import javax.resource.spi.ActivationSpec;
 import javax.resource.spi.InvalidPropertyException;
@@ -450,7 +453,14 @@ public class JmsActivationSpec implements ActivationSpec {
         buffer.append(" minSession=").append(minSession);
         buffer.append(" maxSession=").append(maxSession);
         buffer.append(" connectionFactory=").append(connectionFactory);
-        buffer.append(" jndiParameters=").append(jndiParameters);
+
+        if (jndiParameters != null) {
+            Properties properties = JmsActivation.convertStringToProperties(jndiParameters);
+            if(properties.containsKey(Context.SECURITY_CREDENTIALS)) {
+                properties.put(Context.SECURITY_CREDENTIALS, "<not shown>");
+            }
+            buffer.append(" jndiParameters=").append(properties);
+        }
         buffer.append(')');
         return buffer.toString();
     }


### PR DESCRIPTION
in JmsActivationSpec#toString, convert the jndiParameters string to a
Properties and replaces the value for the SECURITY_CREDENTIALS by "<not
shown>".
