### PR TITLE
check whether a transaction is active

### DIFF
--- a/generic-jms-ra-jar/src/main/java/org/jboss/resource/adapter/jms/JmsMCFProperties.java
+++ b/generic-jms-ra-jar/src/main/java/org/jboss/resource/adapter/jms/JmsMCFProperties.java
@@ -46,6 +46,11 @@ public class JmsMCFProperties implements java.io.Serializable {
     String connectionFactory;
     int type = JmsConnectionFactory.AGNOSTIC;
 
+    /**
+     * The JNDI name to lookup the TransactionSynchronizationRegistry
+     */
+    private String transactionSynchronizationRegistryLookup;
+
     public JmsMCFProperties() {
         // empty
     }
@@ -120,6 +125,14 @@ public class JmsMCFProperties implements java.io.Serializable {
 
     public void setJndiParameters(String jndiParameters) {
         this.jndiParameters = jndiParameters;
+    }
+
+    public String getTransactionSynchronizationRegistryLookup() {
+        return transactionSynchronizationRegistryLookup;
+    }
+
+    public void setTransactionSynchronizationRegistryLookup(String transactionSynchronizationRegistryLookup) {
+        this.transactionSynchronizationRegistryLookup = transactionSynchronizationRegistryLookup;
     }
 
     /**

--- a/generic-jms-ra-jar/src/main/java/org/jboss/resource/adapter/jms/JmsManagedConnectionFactory.java
+++ b/generic-jms-ra-jar/src/main/java/org/jboss/resource/adapter/jms/JmsManagedConnectionFactory.java
@@ -300,6 +300,14 @@ public class JmsManagedConnectionFactory implements ManagedConnectionFactory {
         return deleteTemporaryDestinations;
     }
 
+    public void setTransactionSynchronizationRegistryLookup(String transactionSynchronizationRegistryLookup) {
+        mcfProperties.setTransactionSynchronizationRegistryLookup(transactionSynchronizationRegistryLookup);
+    }
+
+    public String getTransactionSynchronizationRegistryLookup() {
+        return mcfProperties.getTransactionSynchronizationRegistryLookup();
+    }
+
     private ConnectionRequestInfo getInfo(ConnectionRequestInfo info) {
         if (info == null) {
             // Create a default one
@@ -320,4 +328,5 @@ public class JmsManagedConnectionFactory implements ManagedConnectionFactory {
     protected JmsMCFProperties getProperties() {
         return mcfProperties;
     }
+
 }

--- a/generic-jms-ra-jar/src/main/java/org/jboss/resource/adapter/jms/JmsMessageConsumer.java
+++ b/generic-jms-ra-jar/src/main/java/org/jboss/resource/adapter/jms/JmsMessageConsumer.java
@@ -80,18 +80,12 @@ public class JmsMessageConsumer implements MessageConsumer {
         }
     }
 
-    void checkState() throws JMSException {
-        session.checkTransactionActive();
-    }
-
     public MessageListener getMessageListener() throws JMSException {
-        checkState();
         session.checkStrict();
         return consumer.getMessageListener();
     }
 
     public String getMessageSelector() throws JMSException {
-        checkState();
         return consumer.getMessageSelector();
     }
 
@@ -100,7 +94,6 @@ public class JmsMessageConsumer implements MessageConsumer {
         try {
             if (trace)
                 log.trace("receive " + this);
-            checkState();
             Message message = consumer.receive();
             if (trace)
                 log.trace("received " + this + " result=" + message);
@@ -118,7 +111,6 @@ public class JmsMessageConsumer implements MessageConsumer {
         try {
             if (trace)
                 log.trace("receive " + this + " timeout=" + timeout);
-            checkState();
             Message message = consumer.receive(timeout);
             if (trace)
                 log.trace("received " + this + " result=" + message);
@@ -136,7 +128,6 @@ public class JmsMessageConsumer implements MessageConsumer {
         try {
             if (trace)
                 log.trace("receiveNoWait " + this);
-            checkState();
             Message message = consumer.receiveNoWait();
             if (trace)
                 log.trace("received " + this + " result=" + message);
@@ -152,7 +143,6 @@ public class JmsMessageConsumer implements MessageConsumer {
     public void setMessageListener(MessageListener listener) throws JMSException {
         session.lock();
         try {
-            checkState();
             session.checkStrict();
             if (listener == null)
                 consumer.setMessageListener(null);

--- a/generic-jms-ra-jar/src/main/java/org/jboss/resource/adapter/jms/JmsMessageProducer.java
+++ b/generic-jms-ra-jar/src/main/java/org/jboss/resource/adapter/jms/JmsMessageProducer.java
@@ -81,7 +81,6 @@ public class JmsMessageProducer implements MessageProducer {
         try {
             if (trace)
                 log.trace("send " + this + " destination=" + destination + " message=" + message + " deliveryMode=" + deliveryMode + " priority=" + priority + " ttl=" + timeToLive);
-            checkState();
             producer.send(destination, message, deliveryMode, priority, timeToLive);
             if (trace)
                 log.trace("sent " + this + " result=" + message);
@@ -95,7 +94,6 @@ public class JmsMessageProducer implements MessageProducer {
         try {
             if (trace)
                 log.trace("send " + this + " destination=" + destination + " message=" + message);
-            checkState();
             producer.send(destination, message);
             if (trace)
                 log.trace("sent " + this + " result=" + message);
@@ -109,7 +107,6 @@ public class JmsMessageProducer implements MessageProducer {
         try {
             if (trace)
                 log.trace("send " + this + " message=" + message + " deliveryMode=" + deliveryMode + " priority=" + priority + " ttl=" + timeToLive);
-            checkState();
             producer.send(message, deliveryMode, priority, timeToLive);
             if (trace)
                 log.trace("sent " + this + " result=" + message);
@@ -123,7 +120,6 @@ public class JmsMessageProducer implements MessageProducer {
         try {
             if (trace)
                 log.trace("send " + this + " message=" + message);
-            checkState();
             producer.send(message);
             if (trace)
                 log.trace("sent " + this + " result=" + message);
@@ -174,10 +170,6 @@ public class JmsMessageProducer implements MessageProducer {
 
     public void setTimeToLive(long timeToLive) throws JMSException {
         producer.setTimeToLive(timeToLive);
-    }
-
-    void checkState() throws JMSException {
-        session.checkTransactionActive();
     }
 
     void closeProducer() throws JMSException {

--- a/generic-jms-ra-jar/src/main/java/org/jboss/resource/adapter/jms/JmsQueueReceiver.java
+++ b/generic-jms-ra-jar/src/main/java/org/jboss/resource/adapter/jms/JmsQueueReceiver.java
@@ -42,7 +42,6 @@ public class JmsQueueReceiver extends JmsMessageConsumer implements QueueReceive
     }
 
     public Queue getQueue() throws JMSException {
-        checkState();
         return ((QueueReceiver) consumer).getQueue();
     }
 }

--- a/generic-jms-ra-jar/src/main/java/org/jboss/resource/adapter/jms/JmsQueueSender.java
+++ b/generic-jms-ra-jar/src/main/java/org/jboss/resource/adapter/jms/JmsQueueSender.java
@@ -60,7 +60,6 @@ public class JmsQueueSender extends JmsMessageProducer implements QueueSender {
         try {
             if (trace)
                 log.trace("send " + this + " destination=" + destination + " message=" + message + " deliveryMode=" + deliveryMode + " priority=" + priority + " ttl=" + timeToLive);
-            checkState();
             producer.send(destination, message, deliveryMode, priority, timeToLive);
             if (trace)
                 log.trace("sent " + this + " result=" + message);
@@ -74,7 +73,6 @@ public class JmsQueueSender extends JmsMessageProducer implements QueueSender {
         try {
             if (trace)
                 log.trace("send " + this + " destination=" + destination + " message=" + message);
-            checkState();
             producer.send(destination, message);
             if (trace)
                 log.trace("sent " + this + " result=" + message);

--- a/generic-jms-ra-jar/src/main/java/org/jboss/resource/adapter/jms/JmsSession.java
+++ b/generic-jms-ra-jar/src/main/java/org/jboss/resource/adapter/jms/JmsSession.java
@@ -148,17 +148,10 @@ public class JmsSession implements Session, QueueSession, TopicSession {
         if (mc == null)
             throw new IllegalStateException("The session is closed");
 
-        checkTransactionActive();
-
         Session session = mc.getSession();
         if (trace)
             log.trace("getSession " + session + " for " + this);
         return session;
-    }
-
-    void checkTransactionActive() throws IllegalStateException {
-        if (sf != null)
-            sf.checkTransactionActive();
     }
 
     // ---- Session API

--- a/generic-jms-ra-jar/src/main/java/org/jboss/resource/adapter/jms/JmsTopicPublisher.java
+++ b/generic-jms-ra-jar/src/main/java/org/jboss/resource/adapter/jms/JmsTopicPublisher.java
@@ -63,7 +63,6 @@ public class JmsTopicPublisher extends JmsMessageProducer implements TopicPublis
         }
         if (trace)
             log.trace("send " + this + " message=" + message + " deliveryMode=" + deliveryMode + " priority=" + priority + " ttl=" + timeToLive);
-        checkState();
         ((TopicPublisher) producer).publish(message, deliveryMode, priority, timeToLive);
         if (trace)
             log.trace("sent " + this + " result=" + message);
@@ -74,7 +73,6 @@ public class JmsTopicPublisher extends JmsMessageProducer implements TopicPublis
         try {
             if (trace)
                 log.trace("send " + this + " message=" + message);
-            checkState();
             ((TopicPublisher) producer).publish(message);
             if (trace)
                 log.trace("sent " + this + " result=" + message);
@@ -89,7 +87,6 @@ public class JmsTopicPublisher extends JmsMessageProducer implements TopicPublis
         try {
             if (trace)
                 log.trace("send " + this + " destination=" + destination + " message=" + message + " deliveryMode=" + deliveryMode + " priority=" + priority + " ttl=" + timeToLive);
-            checkState();
             ((TopicPublisher) producer).publish(destination, message, deliveryMode, priority, timeToLive);
             if (trace)
                 log.trace("sent " + this + " result=" + message);
@@ -103,7 +100,6 @@ public class JmsTopicPublisher extends JmsMessageProducer implements TopicPublis
         try {
             if (trace)
                 log.trace("send " + this + " destination=" + destination + " message=" + message);
-            checkState();
             ((TopicPublisher) producer).publish(destination, message);
             if (trace)
                 log.trace("sent " + this + " result=" + message);

--- a/generic-jms-ra-jar/src/main/java/org/jboss/resource/adapter/jms/JmsTopicSubscriber.java
+++ b/generic-jms-ra-jar/src/main/java/org/jboss/resource/adapter/jms/JmsTopicSubscriber.java
@@ -42,12 +42,10 @@ public class JmsTopicSubscriber extends JmsMessageConsumer implements TopicSubsc
     }
 
     public boolean getNoLocal() throws JMSException {
-        checkState();
         return ((TopicSubscriber) consumer).getNoLocal();
     }
 
     public Topic getTopic() throws JMSException {
-        checkState();
         return ((TopicSubscriber) consumer).getTopic();
     }
 }

--- a/generic-jms-ra-rar/src/main/rar/META-INF/ra.xml
+++ b/generic-jms-ra-rar/src/main/rar/META-INF/ra.xml
@@ -98,6 +98,12 @@
                     <config-property-type>java.lang.Boolean</config-property-type>
                     <config-property-value>true</config-property-value>
                 </config-property>
+                <config-property>
+                    <description>The JNDI name to lookup the TransactionSynchronizationRegistry.</description>
+                    <config-property-name>TransactionSynchronizationRegistryLookup</config-property-name>
+                    <config-property-type>java.lang.String</config-property-type>
+                    <config-property-value></config-property-value>
+                </config-property>
                 <connectionfactory-interface>org.jboss.resource.adapter.jms.JmsConnectionFactory
                 </connectionfactory-interface>
                 <connectionfactory-impl-class>org.jboss.resource.adapter.jms.JmsConnectionFactoryImpl


### PR DESCRIPTION
to ignore the transacted and acknowlegeMode if there is an active
transaction.

The check is done using the TransactionSynchronizationRegistry object
that is looked up in JNDI using the
TransactionSynchronizationRegistryLookup config property.
By default, the property is not set and a RA will consider that a
transaction is active and will create the JMS session accordingly.

To specify the TransactionSynchronizationRegistryLookup to use, add a
config-property to ra.xml. For example

   <config-property>
      <description>The JNDI name to lookup the TransactionSynchronizationRegistry.</description>
      <config-property-name>TransactionSynchronizationRegistryLookup</config-property-name>
      <config-property-type>java.lang.String</config-property-type>
      <config-property-value>java:jboss/TransactionSynchronizationRegistry</config-property-value>
   </config-property>

Remove the checkState() method that is no longer correct since the RA
can used without active transaction (and the method in
JmsSessionFactoryImpl was not doing any checks prior to the previous
commit anyway).

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1033008
