### PR TITLE
Remove dependency on JBoss Common Core. The code used from JBoss Common ...

### DIFF
--- a/generic-jms-ra-jar/pom.xml
+++ b/generic-jms-ra-jar/pom.xml
@@ -24,6 +24,12 @@
             <groupId>org.jboss.javaee</groupId>
             <artifactId>jboss-jca-api</artifactId>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss</groupId>
+                    <artifactId>jboss-common-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.jms</groupId>

--- a/generic-jms-ra-jar/src/main/java/org/jboss/resource/adapter/jms/JmsConnectionRequestInfo.java
+++ b/generic-jms-ra-jar/src/main/java/org/jboss/resource/adapter/jms/JmsConnectionRequestInfo.java
@@ -25,7 +25,7 @@ import javax.resource.spi.ConnectionRequestInfo;
 
 import javax.jms.Session;
 
-import org.jboss.util.Strings;
+import org.jboss.resource.adapter.jms.util.Strings;
 
 /**
  * Request information used in pooling

--- a/generic-jms-ra-jar/src/main/java/org/jboss/resource/adapter/jms/JmsMCFProperties.java
+++ b/generic-jms-ra-jar/src/main/java/org/jboss/resource/adapter/jms/JmsMCFProperties.java
@@ -25,7 +25,7 @@ import javax.jms.Queue;
 import javax.jms.Topic;
 import javax.resource.ResourceException;
 
-import org.jboss.util.Strings;
+import org.jboss.resource.adapter.jms.util.Strings;
 
 /**
  * The MCF default properties, settable in ra.xml or in deployer.
@@ -147,7 +147,7 @@ public class JmsMCFProperties implements java.io.Serializable {
     }
 
     /**
-     * Test for equality of all attributes.
+     * Test for equality.
      */
     public boolean equals(Object obj) {
         if (obj == null) return false;

--- a/generic-jms-ra-jar/src/main/java/org/jboss/resource/adapter/jms/util/Strings.java
+++ b/generic-jms-ra-jar/src/main/java/org/jboss/resource/adapter/jms/util/Strings.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.resource.adapter.jms.util;
+
+public class Strings
+{
+    public static boolean compare(final String me, final String you)
+    {
+        // If both null or intern equals
+        if (me == you)
+           return true;
+
+        // if me null and you are not
+        if (me == null && you != null)
+           return false;
+
+        // me will not be null, test for equality
+        return me.equals(you);
+    }
+}


### PR DESCRIPTION
...Core is exceedingly simple. No need to enforce an external dependency for something so trivial. If the dependency hadn't snuck in via jboss-jca-api it would have been removed long ago.
