### PR TITLE
[BZ1378723/WFLY-7202] -  generic-jms-ra's JmsMCFProperties.getSession…

### DIFF
--- a/generic-jms-ra-jar/src/main/java/org/jboss/resource/adapter/jms/JmsMCFProperties.java
+++ b/generic-jms-ra-jar/src/main/java/org/jboss/resource/adapter/jms/JmsMCFProperties.java
@@ -141,9 +141,9 @@ public class JmsMCFProperties implements java.io.Serializable {
         if (type == JmsConnectionFactory.AGNOSTIC)
             return "agnostic";
         else if (type == JmsConnectionFactory.QUEUE)
-            return TOPIC_TYPE;
-        else
             return QUEUE_TYPE;
+        else
+            return TOPIC_TYPE;
     }
 
     /**


### PR DESCRIPTION
generic-jms-ra's JmsMCFProperties.getSessionDefaultType returns incorrect value for session type

https://bugzilla.redhat.com/show_bug.cgi?id=1378723
https://issues.jboss.org/browse/WFLY-7202
