### PR TITLE
Allow for equals (=) within JNDI parameter value

### DIFF
--- a/generic-jms-ra-jar/src/main/java/org/jboss/resource/adapter/jms/inflow/JmsActivation.java
+++ b/generic-jms-ra-jar/src/main/java/org/jboss/resource/adapter/jms/inflow/JmsActivation.java
@@ -338,7 +338,7 @@ public class JmsActivation implements ExceptionListener {
         if (jndiParameters != null) {
             String[] elements = jndiParameters.split(";");
             for (String element : elements) {
-                String[] nameValue = element.split("=");
+                String[] nameValue = element.split("=", 2);
                 if (nameValue.length == 2) {
                     properties.setProperty(nameValue[0], nameValue[1]);
                 }


### PR DESCRIPTION
The connection string for Apache Qpid-JMS is an example of a situation that requires = within a JNDI parameter