### PR TITLE
Improve debuggability by linking the cause

### DIFF
--- a/generic-jms-ra-jar/src/main/java/org/jboss/resource/adapter/jms/JmsConnectionFactoryImpl.java
+++ b/generic-jms-ra-jar/src/main/java/org/jboss/resource/adapter/jms/JmsConnectionFactoryImpl.java
@@ -245,9 +245,11 @@ public class JmsConnectionFactoryImpl implements JmsConnectionFactory, Reference
             }
             JMSException jmse = findRootJMSException(e);
             if (jmse instanceof JMSSecurityException) {
-                throw new JMSSecurityRuntimeException(jmse.getMessage());
+                JMSSecurityRuntimeException rte = new JMSSecurityRuntimeException(jmse.getMessage(), jmse.getErrorCode(), jmse);
+                throw rte;
             } else {
-                throw new JMSRuntimeException(e.getMessage());
+                JMSRuntimeException rte = new JMSRuntimeException(e.getMessage(), e.getErrorCode(), e);
+                throw rte;
             }
         }
     }

--- a/generic-jms-ra-jar/src/main/java/org/jboss/resource/adapter/jms/JmsSessionFactoryImpl.java
+++ b/generic-jms-ra-jar/src/main/java/org/jboss/resource/adapter/jms/JmsSessionFactoryImpl.java
@@ -453,6 +453,7 @@ public class JmsSessionFactoryImpl implements JmsSessionFactory, Referenceable {
             log.error("could not create session", e);
 
             JMSException je = new JMSException("Could not create a session: " + e);
+            je.initCause(e);
             je.setLinkedException(e);
             throw je;
         }


### PR DESCRIPTION
While debugging a problem using the Generic JMS RA to connect AMQP to
Rabbit MQ the lack of visible linked exceptions in the stack made it
impossible to determine why things were not working. First the
createContext method threw away the caught exceptions completely, and
then the JMSSessionFactoryImpl set the linked exception, but this was
hidden when stack traces were output in logs, so by also calling
initCause all the useful failure exceptions suddenly became visible.