### PR TITLE
Support Apache QPID JNDI paramaters

### DIFF
--- a/generic-jms-ra-jar/src/main/java/org/jboss/resource/adapter/jms/inflow/JmsActivation.java
+++ b/generic-jms-ra-jar/src/main/java/org/jboss/resource/adapter/jms/inflow/JmsActivation.java
@@ -340,10 +340,10 @@ public class JmsActivation implements ExceptionListener {
         if (jndiParameters != null) {
             String[] elements = jndiParameters.split(";");
             for (String element : elements) {
-                String[] nameValue = element.split("=");
-                if (nameValue.length == 2) {
-                    properties.setProperty(nameValue[0], nameValue[1]);
-                }
+                int index = element.indexOf('=');
+                String name = element.substring(0, index);
+                String value = element.substring(index + 1);
+                properties.setProperty(name, value);
             }
         }
         return properties;


### PR DESCRIPTION
Apache QPID supports JNDI config where the connection factory name has a
value of a url with name value pairs. The syntax is here https://qpid.apache.org/releases/qpid-jms-0.25.0/docs/index.html

The parsing in the generic JMS assumes the value does not include an =
and if it does throws the entry away. This update changes to split name
from value based on the first = and allow equals later on. This allows
Apache QPID JNDI Parameters to work.