### PR TITLE
[WFLY-14378]: Generic JMS RA fails to authenticate.

### DIFF
--- a/generic-jms-ra-jar/src/main/java/org/jboss/resource/adapter/jms/inflow/JmsActivation.java
+++ b/generic-jms-ra-jar/src/main/java/org/jboss/resource/adapter/jms/inflow/JmsActivation.java
@@ -410,7 +410,7 @@ public class JmsActivation implements ExceptionListener {
         log.debug("setup connection " + this);
 
         String user = spec.getUser();
-        char[] pass = spec.getPassword();
+        char[] pass = spec.getPasswordChars();
         String clientID = spec.getClientId();
         String connectionFactory = spec.getConnectionFactory();
 

--- a/generic-jms-ra-jar/src/main/java/org/jboss/resource/adapter/jms/inflow/JmsActivationSpec.java
+++ b/generic-jms-ra-jar/src/main/java/org/jboss/resource/adapter/jms/inflow/JmsActivationSpec.java
@@ -361,8 +361,18 @@ public class JmsActivationSpec implements ActivationSpec {
 
     /**
      * @return the password.
+     * @deprecated use getPasswordChars
      */
-    public char[] getPassword() {
+    @Deprecated
+    public String getPassword() {
+        log.warn("You shouldn't use getPassword() on JMSActivationSpec");
+        return Strings.fromCharArray(getPasswordChars());
+    }
+
+    /**
+     * @return the password.
+     */
+    public char[] getPasswordChars() {
         return pass;
     }
 


### PR DESCRIPTION
* Beanutils doens't work when getPassword doesn't return the same type
  as setPassword

Jira: https://issues.redhat.com/browse/WFLY-14378